### PR TITLE
Wrap call to write() in directio_stubs.c with {enter/leave}_blocking_section

### DIFF
--- a/ocaml/xapi/directio_stubs.c
+++ b/ocaml/xapi/directio_stubs.c
@@ -68,7 +68,9 @@ static void really_write(int fd, void *aligned_buffer, int len){
   int n;
 
   while (len > 0) {
+    enter_blocking_section();
     n = write(fd, aligned_buffer, len);
+    leave_blocking_section();
     if (n == 0) caml_failwith("short write");
     len -= n;
     aligned_buffer += n;


### PR DESCRIPTION
I compared the implementation of really_write in directio_stubs.c with that of unix_write in ocaml/otherlibs/unix/write.c, and it looks like we're missing calls to {enter/leave}_blocking_section around the call to write(). See here: https://github.com/ocaml/ocaml/blob/4.01/otherlibs/unix/write.c#L42